### PR TITLE
fix : entity 조회 시 validateAttrsFiltering에서 rdb는 toLowerCase 하지 않도록 수정

### DIFF
--- a/dataservicebroker/src/main/java/kr/re/keti/sc/dataservicebroker/entities/service/DefaultEntitySVC.java
+++ b/dataservicebroker/src/main/java/kr/re/keti/sc/dataservicebroker/entities/service/DefaultEntitySVC.java
@@ -2863,13 +2863,22 @@ public abstract class DefaultEntitySVC implements EntitySVCInterface<DynamicEnti
 	           return false;
 	        }
 
-	        boolean isMatch = false;
-	        for(String attr : attrs) {
-	            if(commonEntityFullVO.containsKey(attr.toLowerCase())) {
-	                isMatch = true;
-	                break;
-	            }
-	        }
+            boolean isMatch = false;
+            if (this.entityDAO.toString().contains("rdb")) {
+                for(String attr : attrs) {
+                    if(commonEntityFullVO.containsKey(attr)) {
+                        isMatch = true;
+                        break;
+                    }
+                }
+            } else {
+                for (String attr : attrs) {
+                    if (commonEntityFullVO.containsKey(attr.toLowerCase())) {
+                        isMatch = true;
+                        break;
+                    }
+                }
+            }
 	        if(isMatch) {
 	            return false;
 	        }


### PR DESCRIPTION
fix

- entity 조회 시, attrs 파라미터를 대소문자 섞어서 조회 할 수 있도록 수정
    - rdb :  attr을 그대로 넘김
    -  hive/hbase : attr을 소문자로 변경(toLowerCase)헤서 넘김